### PR TITLE
Fix CSS duplication and lazy-load images

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -510,14 +510,6 @@ a:hover {
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
 }
 
-body {
-  background: #383636;
-  color: #fede50;
-  font-family: system-ui, sans-serif;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 2rem;
-}
 
 h1,
 h2 {
@@ -593,8 +585,7 @@ p {
   .logo {
     margin-top: 1.5rem; /* 👈 mobiltilpasning for logoen */
   }
-}
-@media (max-width: 600px) {
+
   .pricing-table {
     font-size: 0.85rem;
   }
@@ -607,9 +598,8 @@ p {
   .note {
     font-size: 0.85rem;
   }
-}
-/* Eksempelseksjon – galleri */
-@media (max-width: 600px) {
+
+  /* Eksempelseksjon – galleri */
   .gallery {
     flex-direction: column;
     gap: 1rem;
@@ -623,11 +613,11 @@ p {
   .example p {
     font-size: 0.8rem;
   }
-}
-/* Responsiv for mobil */
-@media (max-width: 600px) {
+
+  /* Responsiv for mobil */
   .choose-path {
     flex-direction: column;
     align-items: center;
   }
 }
+

--- a/lag-nettside.html
+++ b/lag-nettside.html
@@ -30,15 +30,15 @@
       <h2>📸 Eksempler jeg har laget</h2>
       <div class="gallery">
         <div class="example">
-          <img src="assets/images/butikkoversikt-desktop.webp" alt="Butikkoversikt.no" />
+          <img loading="lazy" src="assets/images/butikkoversikt-desktop.webp" alt="Butikkoversikt.no" />
           <p><strong>Butikkoversikt.no</strong> – katalog og søkefunksjon for norske nettbutikker</p>
         </div>
         <div class="example">
-          <img src="assets/images/gamer-desktop.webp" alt="CRE8XF portefølje" />
+          <img loading="lazy" src="assets/images/gamer-desktop.webp" alt="CRE8XF portefølje" />
           <p><strong>Gamer Side</strong> – Egen Gaming side</p>
         </div>
         <div class="example">
-          <img src="assets/images/cre8xf-desktop.webp" alt="CRE8XF prosjektoversikt" />
+          <img loading="lazy" src="assets/images/cre8xf-desktop.webp" alt="CRE8XF prosjektoversikt" />
           <p><strong>CRE8XF.dev</strong> – kurs og formidling med moderne design</p>
         </div>
        


### PR DESCRIPTION
## Summary
- remove redundant `body` rule from CSS
- consolidate mobile media queries
- lazy load gallery images on `lag-nettside.html`

## Testing
- `find . -maxdepth 2 -name '*test*'`

------
https://chatgpt.com/codex/tasks/task_e_685f97483ee48325b1576ce1fcd0f997