### PR TITLE
Update AI course headlines and CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <header class="hero">
       <div class="hero-content">
         <img src="assets/images/cre8xf-logo.webp" alt="CRE8XF Logo" class="logo" />
-        <h1>Velkommen til CRE8XF</h1>
+        <h1>Lær AI med CRE8XF – helt gratis</h1>
         <p class="intro-text">
           Jeg er Roger, utvikleren bak <a href="https://butikkoversikt.no" target="_blank"
             rel="noopener">butikkoversikt.no</a> og CRE8XF – søstersider laget for å gjøre teknologi, AI og digitale verktøy
@@ -31,7 +31,7 @@
       <div class="option-box ai">
         <h3>🧠 Jeg vil lære AI</h3>
         <p>Gratis AI-kurs og bonusmateriale for deg som vil komme i gang med ChatGPT og AI-verktøy – uten innlogging.</p>
-        <a href="#overview" class="btn">Start gratis AI-kurs</a>
+        <a href="#overview" class="btn">Prøv gratis nå</a>
       </div>
     </div>
     
@@ -70,11 +70,11 @@
     <section id="overview">
       <h1>🎓 Velkommen til AI-kurspakken fra CRE8XF</h1>
 
-      <p>Her får du tilgang til praktiske AI-kurs og bonusmateriale – helt gratis og uten innlogging.</p>
+      <p>Her finner du enkle AI-kurs og ekstra ressurser som hjelper deg i gang med ChatGPT og andre verktøy. Alt er gratis og krever ingen innlogging.</p>
 
       <h2>📚 Hva kurspakken inneholder</h2>
       <ul>
-        <li><a href="kurs/index.html">📘 Start AI-kurset – Velg nybegynner eller jobbfokus</a></li>
+        <li><a href="kurs/index.html">📘 Start kurset nå – Velg nybegynner eller jobbfokus</a></li>
         <li><a href="bonus/bonus.html">🎁 Bonusmateriale: AI-verktøy, øvelser og tips</a></li>
         <li><a href="teaser-ai-chatgpt.html" target="_blank" rel="noopener">📚 Kursoversikt og innhold (nettvisning)</a></li>
         <li><a href="assets/files/Teaser_AI_kurs_Cre8XF_presentasjon.pdf" target="_blank" rel="noopener">📣 Teaser-presentasjon (PDF)</a></li>

--- a/kurs/index.html
+++ b/kurs/index.html
@@ -11,8 +11,8 @@
 <body>
     <header class="hero">
         <div class="hero-content">
-            <h1>🎓 AI-kurs fra CRE8XF</h1>
-            <p>To praktiske minikurs med bonusmateriale – helt gratis og på norsk.</p>
+            <h1>Lær AI med CRE8XF – helt gratis</h1>
+            <p>To praktiske minikurs med bonusmateriale for deg som er helt ny til AI.</p>
         </div>
     </header>
 
@@ -20,9 +20,9 @@
         <section class="section">
             <h2>📚 Velg et kurs</h2>
             <ul>
-                <li><a href="ai-for-nybegynnere/index.html">🧠 AI for nybegynnere</a> – Kom i gang med
+                <li><a href="ai-for-nybegynnere/index.html">🧠 Start kurset nå</a> – AI for nybegynnere. Kom i gang med
                     ChatGPT og AI-verktøy.</li>
-                <li><a href="kurs-ai-jobb/index.html">💼 AI i arbeidslivet</a> – Bruk AI smart og
+                <li><a href="kurs-ai-jobb/index.html">💼 Prøv gratis nå</a> – AI i arbeidslivet. Bruk AI smart og
                     sikkert på jobb.</li>
             </ul>
         </section>


### PR DESCRIPTION
## Summary
- update hero heading on the front page
- tweak CTA text for the free course
- make introduction text for the course section easier to read
- adjust course overview heading and links

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f9d32ceac83258bad78216ebc53a8